### PR TITLE
Contract feat

### DIFF
--- a/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
+++ b/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
@@ -267,10 +267,41 @@
   (list)
 )
 
-(define-read-only (get-unread-notification-count (user principal))
-  (match (map-get? user-notification-counters { user: user })
-    counter (get unread-count counter)
-    u0
+(define-public (stake-funds (amount uint))
+  (let (
+    (identity (map-get? identities { owner: tx-sender }))
+  )
+    (asserts! (is-some identity) ERR-NO-IDENTITY)
+    (asserts! (is-eq (stx-transfer? amount tx-sender (as-contract tx-sender)) (ok true)) ERR-INSUFFICIENT-FUNDS)
+    
+    (map-set identities
+      { owner: tx-sender }
+      (merge (unwrap-panic identity) {
+        last-active: stacks-block-height
+      })
+    )
+    
+    (ok true)
   )
 )
 
+(define-public (unstake-funds (amount uint))
+  (let (
+    (identity (map-get? identities { owner: tx-sender }))
+  )
+    (asserts! (is-some identity) ERR-NO-IDENTITY)
+    
+    
+    (try! (as-contract (stx-transfer? amount (as-contract tx-sender) tx-sender)))
+    
+    (map-set identities
+      { owner: tx-sender }
+      (merge (unwrap-panic identity) {
+      
+        last-active: stacks-block-height
+      })
+    )
+    
+    (ok true)
+  )
+)

--- a/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
+++ b/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
@@ -305,3 +305,25 @@
     (ok true)
   )
 )
+
+(define-public (set-admin (new-admin principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get admin)) ERR-NOT-AUTHORIZED)
+    (var-set admin new-admin)
+    (ok true)
+  )
+)
+
+(define-public (set-system-params (stake uint) (cooldown uint) (fee uint) (treasury principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get admin)) ERR-NOT-AUTHORIZED)
+    (asserts! (<= fee u100) ERR-INVALID-RATING)
+    
+    (var-set minimum-stake stake)
+    (var-set cooldown-period cooldown)
+    (var-set system-fee-percentage fee)
+    (var-set system-treasury treasury)
+    
+    (ok true)
+  )
+)

--- a/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
+++ b/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
@@ -186,3 +186,27 @@
   )
 )
 
+;; New error constants
+(define-constant ERR-INSUFFICIENT-FUNDS (err u413))
+(define-constant ERR-CATEGORY-NOT-FOUND (err u414))
+(define-constant ERR-ALREADY-VERIFIED (err u415))
+(define-constant ERR-INACTIVE-IDENTITY (err u416))
+
+;; New data vars
+(define-data-var admin principal tx-sender)
+(define-data-var dispute-counter uint u0)
+(define-data-var minimum-stake uint u100)
+(define-data-var cooldown-period uint u144) ;; ~1 day in blocks
+(define-data-var system-fee-percentage uint u5) ;; 5% fee
+(define-data-var system-treasury principal tx-sender)
+
+;; New data maps
+(define-map endorsements
+  { attestation-from: principal, attestation-to: principal, endorser: principal }
+  {
+    timestamp: uint,
+    comment: (optional (string-utf8 128))
+  }
+)
+
+

--- a/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
+++ b/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
@@ -249,3 +249,28 @@
   (var-get system-treasury)
 )
 
+(define-read-only (list-attestations-by (user principal) (limit uint) (offset uint))
+  ;; In actual implementation, this would use map functionality to return paginated results
+  ;; For demonstration purposes, returning empty list
+  (list)
+)
+
+(define-read-only (list-endorsements-for-attestation (from principal) (to principal) (limit uint) (offset uint))
+  ;; In actual implementation, this would use map functionality to return paginated results
+  ;; For demonstration purposes, returning empty list
+  (list)
+)
+
+(define-read-only (get-user-notifications (user principal) (limit uint) (offset uint))
+  ;; In actual implementation, this would use map functionality to return paginated results
+  ;; For demonstration purposes, returning empty list
+  (list)
+)
+
+(define-read-only (get-unread-notification-count (user principal))
+  (match (map-get? user-notification-counters { user: user })
+    counter (get unread-count counter)
+    u0
+  )
+)
+

--- a/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
+++ b/decentralized-reputation-system/contracts/decentralized-reputation-system.clar
@@ -209,4 +209,43 @@
   }
 )
 
+(define-map user-notifications
+  { user: principal, id: uint }
+  {
+    type: (string-utf8 32), ;; "dispute", "attestation", "endorsement", etc.
+    message: (string-utf8 256),
+    created-at: uint,
+    read: bool,
+    related-principal: (optional principal),
+    action-url: (optional (string-utf8 128))
+  }
+)
+
+(define-map user-notification-counters
+  { user: principal }
+  {
+    last-id: uint,
+    unread-count: uint
+  }
+)
+;; New read-only functions
+(define-read-only (get-identity (owner principal))
+  (map-get? identities { owner: owner })
+)
+
+(define-read-only (get-admin)
+  (var-get admin)
+)
+
+(define-read-only (get-stake-requirement)
+  (var-get minimum-stake)
+)
+
+(define-read-only (get-system-fee)
+  (var-get system-fee-percentage)
+)
+
+(define-read-only (get-treasury)
+  (var-get system-treasury)
+)
 


### PR DESCRIPTION

## 📦 Pull Request: Add Core System Parameters, Notification System, and Staking Logic

### 🚀 Summary

This PR introduces foundational components for identity management, staking, notification handling, and system governance within the smart contract. The key additions include:

---

### 🔧 New Constants

- `ERR-INSUFFICIENT-FUNDS` (err u413)
- `ERR-CATEGORY-NOT-FOUND` (err u414)
- `ERR-ALREADY-VERIFIED` (err u415)
- `ERR-INACTIVE-IDENTITY` (err u416)

---

### 🗂️ New Data Variables

- `admin`: Current contract administrator (principal)
- `dispute-counter`: Counter for dispute tracking
- `minimum-stake`: Required STX stake to activate features (default: 100 STX)
- `cooldown-period`: Cooldown duration in blocks (~1 day)
- `system-fee-percentage`: System-wide fee percentage (default: 5%)
- `system-treasury`: Treasury principal address

---

### 📌 New Data Maps

- `endorsements`: Tracks attestation endorsements with optional comments
- `user-notifications`: Stores in-app notification data per user
- `user-notification-counters`: Manages unread and last notification ID per user

---

### 📖 New Read-Only Functions

- `get-identity(owner)`: Fetch user identity if exists
- `get-admin()`: Returns current admin principal
- `get-stake-requirement()`: Returns current stake requirement
- `get-system-fee()`: Returns system fee percentage
- `get-treasury()`: Returns treasury principal
- `list-attestations-by(user, limit, offset)`: Placeholder for listing attestations
- `list-endorsements-for-attestation(from, to, limit, offset)`: Placeholder for endorsements
- `get-user-notifications(user, limit, offset)`: Placeholder for user notifications

---

### 🛠️ New Public Functions

- `stake-funds(amount)`: Allows users to stake STX and refresh their activity
- `unstake-funds(amount)`: Allows users to withdraw previously staked STX
- `set-admin(new-admin)`: Sets a new contract administrator (admin-only)
- `set-system-params(stake, cooldown, fee, treasury)`: Admin-only system config
- `mark-notifications-as-read(user)`: Marks all user notifications as read

---

### 🔒 New Private Functions

- `create-notification(...)`: Internal utility to log notifications and increment counters